### PR TITLE
Behebe Komplikationen zwischen Konfigurator-Elementen und neuem Format

### DIFF
--- a/Discovery/module.php
+++ b/Discovery/module.php
@@ -67,6 +67,14 @@ class HUEDiscovery extends IPSModule
                             'configuration' => [
                                 'Host' => $Bridge['IPv4']
                             ]
+                        ],
+                        [
+                            'moduleID'      => '{2FADB4B7-FDAB-3C64-3E2C-068A4809849A}',
+                            'configuration' => [
+                                'URL'        => 'https://' . $Bridge['IPv4'] . '/eventstream/clip/v2',
+                                'VerifyPeer' => false,
+                                'VerifyHost' => false
+                            ]
                         ]
                     ]
                 ];

--- a/libs/ResourceModule.php
+++ b/libs/ResourceModule.php
@@ -72,7 +72,6 @@ class RessourceModule extends IPSModule
     public function ApplyChanges()
     {
         parent::ApplyChanges();
-        $this->ConnectParent('{6EFF1F3C-DF5F-43F7-DF44-F87EFF149566}');
 
         //Setze Filter für ReceiveData
         $ResourceID = $this->ReadPropertyString('ResourceID');


### PR DESCRIPTION
- Im Discovery die Kette um den SSE Client erweitert
- Im ResourceModule des ConnectParent im ApplyChanges entfernt, wodurch die korrekte Verbindung als die reguläre Bridge kommuniziert wird